### PR TITLE
Add typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.2",
   "description": "yauzl unzipping with Promises",
   "main": "./lib/",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "Overlook Motel"
   },
@@ -18,6 +19,7 @@
     "yauzl-clone": "^1.0.2"
   },
   "devDependencies": {
+    "@types/yauzl": "^2.9.0",
     "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,59 @@
+import { Entry as BaseEntry, Options, ZipFileOptions, RandomAccessReader} from 'yauzl';
+import { Readable } from 'stream';
+import { EventEmitter } from 'events';
+
+export class ZipFile extends EventEmitter {
+    // This chunk taken directly from @types/yauzl
+    autoClose: boolean;
+    comment: string;
+    decodeStrings: boolean;
+    emittedError: boolean;
+    entriesRead: number;
+    entryCount: number;
+    fileSize: number;
+    isOpen: boolean;
+    lazyEntries: boolean;
+    readEntryCursor: boolean;
+    validateEntrySizes: boolean;
+
+    constructor(
+        reader: RandomAccessReader,
+        centralDirectoryOffset: number,
+        fileSize: number,
+        entryCount: number,
+        comment: string,
+        autoClose: boolean,
+        lazyEntries: boolean,
+        decodeStrings: boolean,
+        validateEntrySizes: boolean,
+    );
+
+    // These funcitons are custom to yauzl-promise
+
+    close(): Promise<void>;
+    readEntry(): Promise<Entry>;
+    readEntries(numEntries?: number): Promise<Entry[]>;
+    walkEntries(callback: (entry: Entry) => Promise<void> | void, numEntries?: number): Promise<void>;
+    openReadStream(entry: Entry, options?: ZipFileOptions): Promise<Readable>;
+}
+
+export class Entry extends BaseEntry {
+    openReadStream(options?: ZipFileOptions): Promise<Readable>;
+}
+
+
+export function open(path: string, options?: Options): Promise<ZipFile>;
+// export function open(path: string): Promise<ZipFile>;
+export function fromFd(fd: number, options?: Options): Promise<ZipFile>;
+// export function fromFd(fd: number): Promise<ZipFile>;
+export function fromBuffer(buffer: Buffer, options?: Options): Promise<ZipFile>;
+// export function fromBuffer(buffer: Buffer): Promise<ZipFile>;
+export function fromRandomAccessReader(reader: RandomAccessReader, totalSize: number, options?: Options): Promise<ZipFile>;
+// export function fromRandomAccessReader(reader: RandomAccessReader, totalSize: number): Promise<ZipFile>;
+
+// These are copied directly from @types/yauzl, I beleive they are unmodified
+export function dosDateTimeToDate(date: number, time: number): Date;
+export function validateFileName(fileName: string): string | null;
+
+
+export { RandomAccessReader, Options, ZipFileOptions }


### PR DESCRIPTION
This new file and tiny change to package.json allows this library to be natively used in Typescript projects. It does not effect anyone who is using plain javascript in their project.